### PR TITLE
Remove --privileged from run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ docker run --rm -it --name telegram \
        -e DISPLAY=unix$DISPLAY \
        -v /dev/snd:/dev/snd \
        -v <Your_storage_dir>/.TelegramDesktop:/root/.TelegramDesktop \
-       --privileged \
        xorilog/telegram
 ```
 ## Issues


### PR DESCRIPTION
The `--privileged` flag isn't needed here.
