### PR TITLE
Fixes #9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y \
     python3-dbus \
     software-properties-common \
     libx11-xcb1 \
-    libasound2 \
+    libpulse0 \
     gconf2 \
     libdrm2 \
     libice6 \


### PR DESCRIPTION
Uses libpulse0 instead of libasound2 to fix audio playback and recording. You need a local pulse server and the `PULSE_SERVER=unix:$XDG_RUNTIME_DIR/pulse/native` env var