### PR TITLE
Fixes #9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && apt-get install -y \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Telegram Version 1.9.21
-RUN wget https://updates.tdesktop.com/tlinux/tsetup.1.9.21.tar.xz -O /tmp/telegram.tar.xz \
+# Telegram Version 2.2
+RUN wget https://updates.tdesktop.com/tlinux/tsetup.2.2.0.tar.xz -O /tmp/telegram.tar.xz \
     && cd /tmp/ \
     && tar xvfJ /tmp/telegram.tar.xz \
     && mv /tmp/Telegram/Telegram /usr/bin/Telegram \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y \
     python3-dbus \
     software-properties-common \
     libx11-xcb1 \
-    libasound2 \
+    libpulse0 \
     gconf2 \
     libdrm2 \
     libice6 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,7 @@ RUN apt-get update && apt-get install -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Telegram Version 1.9.21
-COPY --from=downloader /usr/bin/Telegram /usr/bin/Telegram
+COPY --from=downloader --chown=user /usr/bin/Telegram /home/user/Telegram
 
 WORKDIR $HOME
 USER user
@@ -55,4 +54,4 @@ USER user
 ENV QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb
 
 # Autorun Telegram
-CMD ["/usr/bin/Telegram"]
+CMD ["/home/user/Telegram"]

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ To spawn a new instance of Telegram:
 ```shell
 docker run --rm -it --name telegram \
        --hostname=$(hostname) \
-       --device /dev/snd \
        -e DISPLAY=unix$DISPLAY \
+       -e PULSE_SERVER=unix:$XDG_RUNTIME_DIR/pulse/native \
        -v /tmp/.X11-unix:/tmp/.X11-unix \
        -v "/home/$(whoami)/.Xauthority:/home/user/.Xauthority" \
+       -v $XDG_RUNTIME_DIR/pulse:$XDG_RUNTIME_DIR/pulse \
        -v /etc/localtime:/etc/localtime:ro \
        -v <Your_storage_dir>/.TelegramDesktop:/home/user/.local/share/TelegramDesktop/ \
        xorilog/telegram


### PR DESCRIPTION
Uses `libpulse0` instead of `libasound2` to fix audio playback and recording. You need a local pulse server.